### PR TITLE
markdownify post titles since some people use backticks in post title… 

### DIFF
--- a/themes/hugo-xmin/layouts/_default/list.html
+++ b/themes/hugo-xmin/layouts/_default/list.html
@@ -1,7 +1,7 @@
 {{ partial "header.html" . }}
 
 {{if not .IsHome }}
-<h1>{{ .Title }}</h1>
+<h1>{{ .Title | markdownify }}</h1>
 {{ end }}
 
 {{ .Content }}
@@ -10,7 +10,7 @@
   {{ range (where .Data.Pages "Section" "!=" "") }}
   <li>
     <span class="date">{{ .Date.Format "2006/01/02" }}</span>
-    <a href="{{ .URL }}">{{ .Title }}</a>
+    <a href="{{ .URL }}">{{ .Title | markdownify }}</a>
   </li>
   {{ end }}
 </ul>

--- a/themes/hugo-xmin/layouts/_default/single.html
+++ b/themes/hugo-xmin/layouts/_default/single.html
@@ -1,6 +1,6 @@
 {{ partial "header.html" . }}
 <div class="article-meta">
-<h1><span class="title">{{ .Title }}</span></h1>
+<h1><span class="title">{{ .Title | markdownify }}</span></h1>
 {{ with .Params.author }}<h2 class="author">{{ . }}</h2>{{ end }}
 {{ if (gt .Params.date 0) }}<h2 class="date">{{ .Date.Format "2006/01/02" }}</h2>{{ end }}
 </div>


### PR DESCRIPTION
…s, and MathJax will treat content in backticks as inline math

e.g.

@jystatistics: https://jystatistics.rbind.io/post/2018/06/28/study-ggplot2/

@tcgriffith: https://tc.rbind.io/post/2018/01/25/apply-and-do-call/

 yihui committed on Aug 30, 2018
1 parent [9c9c90e](https://github.com/yihui/hugo-xmin/commit/9c9c90e5ab0374627c3cbee1ac0eae3c2b4cc939) commit e658235991d6e6e8d1b5201722054cb1f0d6c3fb 