### PR TITLE
change mathjax cdn from bootcss to rstudio

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -294,7 +294,8 @@ MathJax.Hub.Config({
   }
 });
 </script>
-<script async src="//cdn.bootcss.com/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML">
+<!-- <script async src="//cdn.bootcss.com/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"></script> -->
+<script async src="//mathjax.rstudio.com/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 </script>
 
 <script async src="//yihui.name/js/center-img.js"></script>

--- a/layouts/partials/foot_custom.html
+++ b/layouts/partials/foot_custom.html
@@ -7,7 +7,8 @@ MathJax.Hub.Config({
   }
 });
 </script>
-<script async src="//cdn.bootcss.com/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+<!-- <script async src="//cdn.bootcss.com/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"></script> -->
+<script async src="//mathjax.rstudio.com/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 
 <script async src="//yihui.name/js/center-img.js"></script>
 

--- a/themes/hugo-xmin/exampleSite/content/about.md
+++ b/themes/hugo-xmin/exampleSite/content/about.md
@@ -56,8 +56,8 @@ There are two layout files under `layouts/partials/` that you may want to overri
 
 ```html
 <script src="//yihui.name/js/math-code.js"></script>
-<script async src="//cdn.bootcss.com/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML">
-</script>
+<!-- <script async src="//cdn.bootcss.com/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"></script> -->
+<script async src="//mathjax.rstudio.com/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 
 <script async src="//yihui.name/js/center-img.js"></script>
 ```

--- a/themes/hugo-xmin/exampleSite/layouts/partials/foot_custom.html
+++ b/themes/hugo-xmin/exampleSite/layouts/partials/foot_custom.html
@@ -1,4 +1,4 @@
 <script src="//yihui.name/js/math-code.js"></script>
-<script async src="//cdn.bootcss.com/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"></script>
-
+<!-- <script async src="//cdn.bootcss.com/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"></script> -->
+<script async src="//mathjax.rstudio.com/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 <script async src="//yihui.name/js/center-img.js"></script>


### PR DESCRIPTION
<!-- <script async src="//cdn.bootcss.com/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"></script> -->
<script async src="//mathjax.rstudio.com/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>

 yihui committed on Oct 1, 2018
1 parent [e658235](https://github.com/yihui/hugo-xmin/commit/e658235991d6e6e8d1b5201722054cb1f0d6c3fb) commit 31231a681a43c5b76799a6c340a692175c07ff99 